### PR TITLE
handle associate failure response & fix os info missing from capabili…

### DIFF
--- a/wayk_proto/src/message/connection_sequence/capabilities.rs
+++ b/wayk_proto/src/message/connection_sequence/capabilities.rs
@@ -335,7 +335,7 @@ impl Encode for SystemCapset {
             0
         };
 
-        flags.encoded_len() + os_info_len
+        mem::size_of::<u32>() + os_info_len
     }
 
     fn encode_into<W: Write>(&self, writer: &mut W) -> Result<()> {
@@ -882,7 +882,7 @@ mod tests {
         assert_eq!(capset.encode().unwrap(), UNKNOWN_CAPSET.to_vec(),)
     }
 
-    const PACKET_WITOUT_OS_INFO: [u8; 268] = [
+    const PACKET_WITHOUT_OS_INFO: [u8; 268] = [
         0x08, 0x01, 0x05, 0x80, 0x00, 0x00, 0x00, 0x00, 0x08, 0x14, 0x00, 0x0c, 0x4e, 0x6f, 0x77, 0x54, 0x72, 0x61,
         0x6e, 0x73, 0x70, 0x6f, 0x72, 0x74, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2b, 0x00, 0x0a, 0x4e, 0x6f, 0x77, 0x53,
         0x75, 0x72, 0x66, 0x61, 0x63, 0x65, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3d, 0x07, 0xc5,
@@ -903,7 +903,7 @@ mod tests {
     #[test]
     fn full_decode_packet_without_os_info() {
         let mut buffer = Vec::new();
-        let mut reader = Cursor::new(&PACKET_WITOUT_OS_INFO[..]);
+        let mut reader = Cursor::new(&PACKET_WITHOUT_OS_INFO[..]);
         match NowPacket::read_from(&mut reader, &mut buffer, &VirtChannelsCtx::new()) {
             Ok(_) => {}
             Err(e) => {

--- a/wayk_proto/src/message/connection_sequence/capabilities.rs
+++ b/wayk_proto/src/message/connection_sequence/capabilities.rs
@@ -310,19 +310,73 @@ __flags_struct! {
     }
 }
 
-#[derive(Encode, Decode, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct SystemCapset {
     pub flags: SystemCapsetFlags,
-    pub os_info: NowSystemOsInfo,
+    pub os_info: Option<NowSystemOsInfo>,
 }
 
 impl SystemCapset {
-    const NAME: &'static str = "NowSystem";
+    pub const NAME: &'static str = "NowSystem";
 
     pub fn new_os_info(os_info: NowSystemOsInfo) -> Self {
         Self {
             flags: SystemCapsetFlags::new_empty().set_os_info(),
-            os_info,
+            os_info: Some(os_info),
+        }
+    }
+}
+
+impl Encode for SystemCapset {
+    fn encoded_len(&self) -> usize {
+        let mut os_info_len = 0;
+        if let Some(os_info) = &self.os_info {
+            os_info_len = os_info.encoded_len();
+        }
+
+        mem::size_of::<u16>() + Self::NAME.len() + 2 + mem::size_of::<u32>() + os_info_len
+    }
+
+    fn encode_into<W: Write>(&self, writer: &mut W) -> Result<()> {
+        let name = unsafe { NowString64::from_str_unchecked(Self::NAME) };
+
+        let size = u16::try_from(self.encoded_len())
+            .map_err(ProtoError::from)
+            .chain(ProtoErrorKind::Encoding(stringify!(NowCapset)))
+            .or_desc("capset data too large for the size field")?;
+
+        size.encode_into(writer)?;
+        name.encode_into(writer)?;
+        self.flags.encode_into(writer)?;
+        if let Some(os_info) = &self.os_info {
+            os_info.encode_into(writer)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'dec: 'a, 'a> Decode<'dec> for SystemCapset {
+    fn decode_from(cursor: &mut Cursor<&'dec [u8]>) -> Result<Self> {
+        let flags = cursor.read_u32::<LittleEndian>()?;
+        match flags {
+            SystemCapsetFlags::OS_INFO => match NowSystemOsInfo::decode_from(cursor) {
+                Ok(os_info) => {
+                    return Ok(SystemCapset {
+                        flags: SystemCapsetFlags::new_empty().set_os_info(),
+                        os_info: Some(os_info),
+                    })
+                }
+                Err(e) => {
+                    e.print_trace();
+                    panic!("couldn't decode capabilities packet");
+                }
+            },
+            _ => {
+                return Ok(SystemCapset {
+                    flags: SystemCapsetFlags::new_empty(),
+                    os_info: None,
+                })
+            }
         }
     }
 }
@@ -436,7 +490,7 @@ impl<'a> Encode for NowCapset<'a> {
             NowCapset::Update(capset) => encoded_len_capset_variant!(capset, UpdateCapset),
             NowCapset::Input(capset) => encoded_len_capset_variant!(capset, InputCapset),
             NowCapset::Mouse(capset) => encoded_len_capset_variant!(capset, MouseCapset),
-            NowCapset::System(capset) => encoded_len_capset_variant!(capset, SystemCapset),
+            NowCapset::System(capset) => capset.encoded_len(),
         }
     }
 
@@ -464,9 +518,7 @@ impl<'a> Encode for NowCapset<'a> {
             NowCapset::Mouse(capset) => {
                 encode_capset_variant! {capset, MouseCapset, writer}
             }
-            NowCapset::System(capset) => {
-                encode_capset_variant! {capset, SystemCapset, writer}
-            }
+            NowCapset::System(capset) => capset.encode_into(writer)?,
         }
 
         Ok(())
@@ -848,5 +900,36 @@ mod tests {
             data: &[0x02, 0x29, 0x85, 0x12],
         });
         assert_eq!(capset.encode().unwrap(), UNKNOWN_CAPSET.to_vec(),)
+    }
+
+    const PACKET_WITOUT_OS_INFO: [u8; 268] = [
+        0x08, 0x01, 0x05, 0x80, 0x00, 0x00, 0x00, 0x00, 0x08, 0x14, 0x00, 0x0c, 0x4e, 0x6f, 0x77, 0x54, 0x72, 0x61,
+        0x6e, 0x73, 0x70, 0x6f, 0x72, 0x74, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2b, 0x00, 0x0a, 0x4e, 0x6f, 0x77, 0x53,
+        0x75, 0x72, 0x66, 0x61, 0x63, 0x65, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3d, 0x07, 0xc5,
+        0x03, 0x01, 0x10, 0x00, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3d, 0x07, 0xc5, 0x03,
+        0x2a, 0x00, 0x09, 0x4e, 0x6f, 0x77, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00,
+        0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x35, 0x00, 0x08, 0x4e, 0x6f, 0x77, 0x49, 0x6e, 0x70, 0x75, 0x74, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x10, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x12,
+        0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0x15, 0x00, 0x00, 0x00, 0x16, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00,
+        0x00, 0x01, 0x00, 0x00, 0x00, 0x14, 0x00, 0x08, 0x4e, 0x6f, 0x77, 0x4d, 0x6f, 0x75, 0x73, 0x65, 0x00, 0x01,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x2e, 0x00, 0x09, 0x4e, 0x6f, 0x77, 0x41, 0x63, 0x63, 0x65, 0x73,
+        0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x01, 0x00, 0x01, 0x00, 0x02, 0x00, 0x01,
+        0x00, 0x03, 0x00, 0x01, 0x00, 0x04, 0x00, 0x01, 0x00, 0x05, 0x00, 0x01, 0x00, 0x06, 0x00, 0x01, 0x00, 0x12,
+        0x00, 0x0a, 0x4e, 0x6f, 0x77, 0x4c, 0x69, 0x63, 0x65, 0x6e, 0x73, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11,
+        0x00, 0x09, 0x4e, 0x6f, 0x77, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+
+    #[test]
+    fn full_decode_packet_without_os_info() {
+        let mut buffer = Vec::new();
+        let mut reader = Cursor::new(&PACKET_WITOUT_OS_INFO[..]);
+        match NowPacket::read_from(&mut reader, &mut buffer, &VirtChannelsCtx::new()) {
+            Ok(_) => {}
+            Err(e) => {
+                e.print_trace();
+                panic!("couldn't decode capabilities packet");
+            }
+        }
     }
 }

--- a/wayk_proto/src/message/connection_sequence/capabilities.rs
+++ b/wayk_proto/src/message/connection_sequence/capabilities.rs
@@ -335,7 +335,7 @@ impl Encode for SystemCapset {
             0
         };
 
-        mem::size_of::<u32>() + os_info_len
+        flags.encoded_len() + os_info_len
     }
 
     fn encode_into<W: Write>(&self, writer: &mut W) -> Result<()> {


### PR DESCRIPTION
- handle associate msg failure (this case is triggered when session is already active and we try to connect to that sharer)
- fix : capabilities msg when it receives an empty SystemCapset message (no os info in it)