### PR TITLE
Associate sm

### DIFF
--- a/wayk_proto/src/message/connection_sequence/capabilities.rs
+++ b/wayk_proto/src/message/connection_sequence/capabilities.rs
@@ -335,7 +335,7 @@ impl Encode for SystemCapset {
             0
         };
 
-        mem::size_of::<u32>() + os_info_len
+        self.flags.encoded_len() + os_info_len
     }
 
     fn encode_into<W: Write>(&self, writer: &mut W) -> Result<()> {

--- a/wayk_proto/src/sm/client_connection/sub_sm.rs
+++ b/wayk_proto/src/sm/client_connection/sub_sm.rs
@@ -260,7 +260,7 @@ impl ConnectionSM for AssociateSM {
                 },
                 unexpected => unexpected_msg!(Self, self, unexpected),
             },
-            _ => unexpected_call!(Self, self, "update_with_message"),
+            AssociateState::Terminated => unexpected_call!(Self, self, "update_with_message"),
         }
     }
 }

--- a/wayk_proto/src/sm/client_connection/sub_sm.rs
+++ b/wayk_proto/src/sm/client_connection/sub_sm.rs
@@ -230,13 +230,19 @@ impl ConnectionSM for AssociateSM {
     }
 
     fn update_with_message<'msg: 'a, 'a>(&mut self, msg: &'a NowMessage<'msg>) -> ConnectionSMResult<'msg> {
-        use wayk_proto::message::{status::AssociateStatusCode, NowAssociateMsg};
+        use wayk_proto::message::{status::AssociateStatusCode, AssociateInfoFlags, NowAssociateMsg};
 
         match &self.state {
             AssociateState::WaitInfo => match msg {
-                NowMessage::Associate(NowAssociateMsg::Info(_)) => {
+                NowMessage::Associate(NowAssociateMsg::Info(msg)) => {
                     self.state = AssociateState::WaitResponse;
-                    Ok(Some(NowAssociateMsg::new_request().into()))
+                    match msg.flags.value {
+                        AssociateInfoFlags::ACTIVE => {
+                            log::trace!("associate process session is already active");
+                            Ok(None)
+                        }
+                        _ => Ok(Some(NowAssociateMsg::new_request().into())),
+                    }
                 }
                 unexpected => unexpected_msg!(Self, self, unexpected),
             },
@@ -254,7 +260,7 @@ impl ConnectionSM for AssociateSM {
                 },
                 unexpected => unexpected_msg!(Self, self, unexpected),
             },
-            AssociateState::Terminated => unexpected_call!(Self, self, "update_with_message"),
+            _ => unexpected_call!(Self, self, "update_with_message"),
         }
     }
 }


### PR DESCRIPTION
verify if AssociateInfoFlags::ACTIVE is set. this means that a session is already active. in that case we return an empty result.