### PR TITLE
do not terminate channel on a failure response from sharer

### DIFF
--- a/wayk_proto/src/sm/client_channels/clipboard.rs
+++ b/wayk_proto/src/sm/client_channels/clipboard.rs
@@ -172,7 +172,6 @@ where
 
     fn __check_failure<'msg>(&mut self, flags: ClipboardResponseFlags) -> VirtChannelSMResult<'msg> {
         if flags.failure() {
-            self.state = ClipboardState::Terminated;
             ProtoError::new(ProtoErrorKind::VirtualChannel(self.get_channel_name()))
         } else {
             Ok(None)


### PR DESCRIPTION
do not change state when a failure flag is received from sharer